### PR TITLE
Refactorización: Modificar CAUJUS_dev.ps1 para que admita RunAs con r…

### DIFF
--- a/Scripts/CAUJUS_dev.ps1
+++ b/Scripts/CAUJUS_dev.ps1
@@ -156,7 +156,22 @@ function Invoke-ElevatedCommand {
         return -1 # Indicate failure
     }
 
-    $fullUser = "$($global:adUser)@JUSTICIA"
+    # Determine computer's domain
+    try {
+        $computerDomain = (Get-WmiObject -Class Win32_ComputerSystem -ErrorAction Stop).Domain
+    }
+    catch {
+        $computerDomain = $null # Handle cases where domain is not available or WMI query fails
+    }
+
+    # Set fullUser based on the domain
+    if ($computerDomain -ne $null -and $computerDomain.ToUpper() -eq 'JUSTICIA') {
+        $fullUser = "$($global:adUser)@JUSTICIA"
+    }
+    else {
+        $fullUser = $global:adUser # Use local account if not in JUSTICIA domain or domain is null
+    }
+
     # Ensure the command within quotes is properly escaped if it contains quotes itself.
     # For simple commands passed as strings, direct embedding is often fine.
     # Complex commands might need careful handling of nested quotes.


### PR DESCRIPTION
Reconocimiento de dominio

He actualizado la función `Invoke-ElevatedCommand` en `Scripts/CAUJUS_dev.ps1` para determinar de forma inteligente el contexto de usuario para los comandos `runas`.

Anteriormente, el script siempre añadía "@JUSTICIA" al nombre de usuario proporcionado. Este cambio introduce la detección de dominio:

- El script ahora consulta el dominio actual del equipo.
- Si el dominio se identifica como "JUSTICIA" (sin distinguir entre mayúsculas y minúsculas), el nombre de usuario se calificará con "@JUSTICIA" como antes (p. ej., `usuario@JUSTICIA`).
- Si el dominio es diferente de "JUSTICIA" o si el equipo no está unido a un dominio (p. ej., en un grupo de trabajo), el script usará el nombre de usuario tal cual (p. ej., `usuario`). Esto permite que `runas` se dirija a una cuenta de usuario local en el equipo.

Esta mejora hace que el script sea más versátil, lo que permite usarlo eficazmente en equipos independientemente de su pertenencia al dominio, especialmente al operar como administrador local en sistemas que no sean "JUSTICIA". El registro en `Invoke-ElevatedCommand` reflejará con precisión el principal de usuario utilizado para la elevación.